### PR TITLE
Checks whether a symlink exists before making it.

### DIFF
--- a/fdb/fdb.go
+++ b/fdb/fdb.go
@@ -764,6 +764,12 @@ func (c *Collection) WriteLink(name string, target Link) error {
 		return err
 	}
 
+	// if the link already exists, do nothing
+	existingTo, err := os.Readlink(from)
+	if err == nil && existingTo == toRel {
+		return nil
+	}
+	
 	tmpName, err := tempSymlink(toRel, filepath.Join(c.db.path, "tmp"))
 	if err != nil {
 		return err


### PR DESCRIPTION
If a symlink already exists and points to the file it should go to, we do nothing.
This avoids the unnecessary re-creation of links which change the file data of the link and enclosing directory which make it harder to see when something actually changed.

Fixes #164.